### PR TITLE
Added code needed for intake camera

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -1,5 +1,7 @@
 package frc.robot;
 
+import edu.wpi.first.cameraserver.CameraServer;
+import edu.wpi.first.cscore.UsbCamera;
 import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -44,6 +46,8 @@ public class RobotContainer {
   private final RotatorSubsystem rotator;
   private final TelescopeSubsystem telescope;
 
+  private UsbCamera camera = CameraServer.startAutomaticCapture();
+
   /**
    * The container for the robot. Contains subsystems, OI devices, and commands.
    */
@@ -51,6 +55,10 @@ public class RobotContainer {
     swerve = new DrivebaseSubsystem();
     telescope = new TelescopeSubsystem();
     rotator = new RotatorSubsystem();
+
+
+    camera.setResolution(160, 120);
+    camera.setFPS(30);
 
     swerve.setDefaultCommand(
         new TeleopDrivebaseDefaultCommand(


### PR DESCRIPTION
We are adding a camera at the front of the robot so that our drivers can see what's by the crocodile when across the field. To make it appear on shuffleboard, we need to add a little bit of code to `RobotContainer`. This PR includes some very simple edits:
- A new `USBCamera` object to hold the camera. It is set to automatic capture so that it automatically sends images to the dashboard.
- We then set the resolution as low as possible to maximize FPS

The camera will now appear in the CameraServer column on ShuffleBoard, and the drive team can arrange it as they please.