### PR TITLE
moves on init fix

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -132,10 +132,14 @@ public class RobotContainer {
 
   public void teleopInit() {
     telescope.setToCurrentPosition();
+    rotator.setToCurrentPosition();
+    endEffector.setToCurrentPosition();
   }
 
   public void autonomousInit() {
     telescope.setToCurrentPosition();
+    rotator.setToCurrentPosition();
+    endEffector.setToCurrentPosition();
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/CrocodileSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/CrocodileSubsystem.java
@@ -36,10 +36,10 @@ public class CrocodileSubsystem extends SubsystemBase {
         beamBreak = new DigitalInput(RobotMap.Crocodile.BEAM_BREAK_ID);
         intake.setNeutralMode(NeutralMode.Brake);
         wrist.setNeutralMode(NeutralMode.Brake);
-        /* enabled | Limit(amp) | Trigger Threshold(amp) | Trigger Threshold Time(s) */
-        //intake.configSupplyCurrentLimit(new SupplyCurrentLimitConfiguration(true, 35, 60, 0.1));
-        setWristSetpoint(wristEncoder.getAbsolutePosition());
+    }
 
+    public void setToCurrentPosition() {
+        setWristSetpoint(wristEncoder.getAbsolutePosition());
     }
 
     public void setIntakeSpeed(double speed) {

--- a/src/main/java/frc/robot/subsystems/RotatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/RotatorSubsystem.java
@@ -77,8 +77,6 @@ public class RotatorSubsystem extends SubsystemBase {
                 ROTATOR_KA_COEFF);
 
         encoder = new DutyCycleEncoder(0);
-        // update the rotator PID to the current position
-        setToCurrentPosition();
     }
 
     // Sets the setpoint to where the rotator is currently


### PR DESCRIPTION
Currently, if the rotator or wrist are moved after deploying code, they will move to the position they were when the code was deployed. This created an unexpected movement on init, and is also not what we want. This PR fixes this by doing two things:
 1. The calls to `setToCurrentPosition()` in the constructor are removed.
 2. They are moved to `autonomousInit()` and `teleopInit()` in `RobotContainer`.