### PR TITLE
Fix for telescope movement

### DIFF
--- a/src/main/java/frc/robot/commands/DefaultCommands/TelescopeDefault.java
+++ b/src/main/java/frc/robot/commands/DefaultCommands/TelescopeDefault.java
@@ -20,7 +20,7 @@ public class TelescopeDefault extends CommandBase {
 
     @Override
     public void initialize() {
-        telescopeSubsystem.setToCurrentPosition();
+        // telescopeSubsystem.setToCurrentPosition();
     }
 
     @Override
@@ -31,7 +31,7 @@ public class TelescopeDefault extends CommandBase {
             if (telescopeSubsystem.inBounds()) {
                 telescopeSubsystem.setSpeed(MathUtil.clamp(joystickInput, -0.3, 0.3));
             } else {
-                telescopeSubsystem.setSpeed(MathUtil.clamp(joystickInput, -0.3, 0));
+                telescopeSubsystem.setSpeed(MathUtil.clamp(joystickInput, 0.3, 0));
             }
         } else {
             telescopeSubsystem.setToCurrentPosition();

--- a/src/main/java/frc/robot/commands/DefaultCommands/TelescopeDefault.java
+++ b/src/main/java/frc/robot/commands/DefaultCommands/TelescopeDefault.java
@@ -33,7 +33,10 @@ public class TelescopeDefault extends CommandBase {
             } else {
                 telescopeSubsystem.setSpeed(MathUtil.clamp(joystickInput, 0.3, 0));
             }
+            telescopeSubsystem.setRunPID(false);
         } else {
+            telescopeSubsystem.setRunPID(true);
+
             telescopeSubsystem.setToCurrentPosition();
         }
     }

--- a/src/main/java/frc/robot/commands/TelescopeToPosition.java
+++ b/src/main/java/frc/robot/commands/TelescopeToPosition.java
@@ -13,6 +13,7 @@ public class TelescopeToPosition extends CommandBase {
     public TelescopeToPosition(TelescopeSubsystem telescopeSubsystem, double percent) {
         this.telescopeSubsystem = telescopeSubsystem;
         this.percent = percent;
+        addRequirements(telescopeSubsystem);
     }
 
     @Override

--- a/src/main/java/frc/robot/subsystems/RotatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/RotatorSubsystem.java
@@ -133,7 +133,7 @@ public class RotatorSubsystem extends SubsystemBase {
         double safeSpeed = MathUtil.clamp(speed + ff, -speedLimit, speedLimit);
         // Set the speed of the rotator
         if (runPID) setSpeed(safeSpeed);
-        System.out.println( safeSpeed + " | M:" + getMeasurementDegrees() + " | SP:" + Math.toDegrees(pid.getSetpoint()));
+        // System.out.println( safeSpeed + " | M:" + getMeasurementDegrees() + " | SP:" + Math.toDegrees(pid.getSetpoint()));
         if (log) {
             System.out.println("RotatorPIDOnly.periodic: current setpoint: " + Math.toDegrees(pid.getSetpoint()));
             System.out.println("RotatorPIDOnly.periodic: speed: " + speed);

--- a/src/main/java/frc/robot/subsystems/TelescopeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/TelescopeSubsystem.java
@@ -5,6 +5,8 @@ import com.ctre.phoenix.motorcontrol.FeedbackDevice;
 import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
 
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.filter.Debouncer;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.RobotMap;
@@ -12,11 +14,11 @@ import frc.robot.RobotMap;
 public class TelescopeSubsystem extends SubsystemBase {
     // PID Constants
     // P for telescope PID
-    private static final double P_COEFF = 0.1;
+    private static final double P_COEFF = 0.0001;
     // I for telescope PID
     private static final double I_COEFF = 0.0;
     // D for telescope PID
-    private static final double D_COEFF = 0.025;
+    private static final double D_COEFF = 0;
     // Tolerance for telescope PID
     private static final double POSITIONAL_TOLERANCE = 1000;
     // Velocity tolerance for telescope PID
@@ -36,8 +38,11 @@ public class TelescopeSubsystem extends SubsystemBase {
     // The current setpoint of the telescope
     private double currentSetpoint;
     // The telescope cannot exceed these ticks
-    private final int MAXIMUM_TICKS = -75000;
+    private final int MAXIMUM_TICKS = 75000;
 
+    private boolean runPID = true;
+
+    private final PIDController pid;
     public TelescopeSubsystem() {
         // Config motor settings
         telescopeMotor = new WPI_TalonFX(RobotMap.Telescope.TELESCOPE_ID);
@@ -45,17 +50,20 @@ public class TelescopeSubsystem extends SubsystemBase {
         telescopeMotor.setNeutralMode(NeutralMode.Brake);
         telescopeMotor.configSelectedFeedbackSensor(FeedbackDevice.IntegratedSensor);
         telescopeMotor.configAllowableClosedloopError(0, POSITIONAL_TOLERANCE);
-        // Config motor PID values
-        telescopeMotor.config_kP(0, P_COEFF);
-        telescopeMotor.config_kI(0, I_COEFF);
-        telescopeMotor.config_kD(0, D_COEFF);
-        telescopeMotor.config_kF(0, F_COEFF);
+        // // Config motor PID values
+        // telescopeMotor.config_kP(0, P_COEFF);
+        // telescopeMotor.config_kI(0, I_COEFF);
+        // telescopeMotor.config_kD(0, D_COEFF);
+        // telescopeMotor.config_kF(0, F_COEFF);
+        pid = new PIDController(P_COEFF, I_COEFF, D_COEFF);
+
+        pid.setTolerance(POSITIONAL_TOLERANCE);
         telescopeMotor.setInverted(true);
     }
 
     // Gets the setpoint of the internal PID
     private double getSetpoint() {
-        return currentSetpoint;
+        return pid.getSetpoint();
     }
 
     // Gets the setpoint of the internal PID in a percentage of the maximum
@@ -103,9 +111,10 @@ public class TelescopeSubsystem extends SubsystemBase {
     }
 
     // Tells the PID where to go
-    private void setSetpoint(double positionTicks) {
-        telescopeMotor.set(ControlMode.Position, positionTicks);
-        currentSetpoint = positionTicks;
+    public void setSetpoint(double positionTicks) {
+        // telescopeMotor.set(ControlMode.Position, positionTicks);
+        // currentSetpoint = positionTicks;
+        pid.setSetpoint(positionTicks);
     }
 
     // Returns true if the motor is stalling, false otherwise
@@ -130,7 +139,8 @@ public class TelescopeSubsystem extends SubsystemBase {
 
     // Returns true if the telescope is at its setpoint, false otherwise
     public boolean atSetpoint() {
-        return Math.abs(currentSetpoint - getCurrentPosition()) < POSITIONAL_TOLERANCE;
+        // return Math.abs(currentSetpoint - getCurrentPosition()) < POSITIONAL_TOLERANCE;
+        return pid.atSetpoint();
     }
 
     // Returns true if the telescope is within its upper bound, false otherwise
@@ -138,10 +148,14 @@ public class TelescopeSubsystem extends SubsystemBase {
         return getExtensionPercent() < 1;
     }
 
+
+    public void setRunPID(boolean set){
+        runPID = set;
+    }
     @Override
     public void periodic() {
-        System.out.println(getCurrentPosition() +  " | err:" +  Math.abs(telescopeMotor.getClosedLoopError()));
         System.out.println("Telescope Position: " + getCurrentPosition() + " Telescope Setpoint: "
                 + getSetpoint());
+        if (runPID) setSpeed(MathUtil.clamp(pid.calculate(getCurrentPosition()), -0.2, 0.2));
     }
 }

--- a/src/main/java/frc/robot/subsystems/TelescopeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/TelescopeSubsystem.java
@@ -12,7 +12,7 @@ import frc.robot.RobotMap;
 public class TelescopeSubsystem extends SubsystemBase {
     // PID Constants
     // P for telescope PID
-    private static final double P_COEFF = 0.05;
+    private static final double P_COEFF = 0.1;
     // I for telescope PID
     private static final double I_COEFF = 0.0;
     // D for telescope PID
@@ -36,7 +36,7 @@ public class TelescopeSubsystem extends SubsystemBase {
     // The current setpoint of the telescope
     private double currentSetpoint;
     // The telescope cannot exceed these ticks
-    private final int MAXIMUM_TICKS = 50000;
+    private final int MAXIMUM_TICKS = -75000;
 
     public TelescopeSubsystem() {
         // Config motor settings
@@ -104,6 +104,7 @@ public class TelescopeSubsystem extends SubsystemBase {
     // Tells the PID where to go
     private void setSetpoint(double positionTicks) {
         telescopeMotor.set(ControlMode.Position, positionTicks);
+        currentSetpoint = positionTicks;
     }
 
     // Returns true if the motor is stalling, false otherwise
@@ -128,11 +129,16 @@ public class TelescopeSubsystem extends SubsystemBase {
 
     // Returns true if the telescope is at its setpoint, false otherwise
     public boolean atSetpoint() {
-        return Math.abs(telescopeMotor.getClosedLoopError()) < POSITIONAL_TOLERANCE;
+        return Math.abs(currentSetpoint - getCurrentPosition()) < POSITIONAL_TOLERANCE;
     }
 
     // Returns true if the telescope is within its upper bound, false otherwise
     public boolean inBounds() {
         return getExtensionPercent() < 1;
+    }
+
+    @Override
+    public void periodic() {
+        System.out.println(getCurrentPosition() +  " | err:" +  Math.abs(telescopeMotor.getClosedLoopError()));
     }
 }


### PR DESCRIPTION
While testing movement for the telescope, we found that there was an issue with running the telescope to a position with the PID. We determined this was for a couple reasons.
- Firstly, the `setToCurrentPosition()` call in the initialize of the default command led to some odd behavior. That was removed.
- Secondly, which this PR also fixes, is that `atSetpoint()` does not work properly. I believe we misunderstand what `getClosedLoopError()` does, and so instead we now calculate our own error. To do this, the PR properly updates the `currentSetpoint` variable, then uses that the calculate the true difference.