### PR TITLE
Stop auto intake without tripping beamBreak

### DIFF
--- a/src/main/java/frc/robot/commands/AutoIntakeCommand.java
+++ b/src/main/java/frc/robot/commands/AutoIntakeCommand.java
@@ -5,6 +5,7 @@ import edu.wpi.first.math.filter.Debouncer.DebounceType;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.CrocodileSubsystem;
+import java.util.function.BooleanSupplier;
 
 public class AutoIntakeCommand extends CommandBase {
     private final CrocodileSubsystem crocodileSubsystem;

--- a/src/main/java/frc/robot/commands/AutoIntakeCommand.java
+++ b/src/main/java/frc/robot/commands/AutoIntakeCommand.java
@@ -17,11 +17,16 @@ public class AutoIntakeCommand extends CommandBase {
     public AutoIntakeCommand(CrocodileSubsystem crocodileSubsystem, double speed, BooleanSupplier stopIntake) {
         this.crocodileSubsystem = crocodileSubsystem;
         this.speed = speed;
-        debouncer = new Debouncer(0.5, DebounceType.kBoth);
+        debouncer = new Debouncer(0.5, DebounceType.kFalling);
         timer = new Timer();
         this.stopIntake = stopIntake;
         addRequirements(crocodileSubsystem);
     }
+    //overload autointke and set stopIntake to null
+    public AutoIntakeCommand(CrocodileSubsystem crocodileSubsystem, double speed) {
+        this(crocodileSubsystem, speed, null);
+    }
+
 
     @Override
     public void initialize() {

--- a/src/main/java/frc/robot/commands/AutoIntakeCommand.java
+++ b/src/main/java/frc/robot/commands/AutoIntakeCommand.java
@@ -46,9 +46,9 @@ public class AutoIntakeCommand extends CommandBase {
                 return true;
             }
         }
-        //otherwise, keep running motors until beam break has been broken 
-        else if(!crocodileSubsystem.getBeamBreak()){
-            return  true;
+        //otherwise, keep running motors until beam break has been broken for 0.5 seconds
+        else if(!debouncer.calculate(crocodileSubsystem.getBeamBreak())){
+            return true;
         }
         //if none of the above, return the value of stopIntake which is bound to a button, unless it is null
         if(stopIntake != null){

--- a/src/main/java/frc/robot/commands/AutoIntakeCommand.java
+++ b/src/main/java/frc/robot/commands/AutoIntakeCommand.java
@@ -22,11 +22,11 @@ public class AutoIntakeCommand extends CommandBase {
         this.stopIntake = stopIntake;
         addRequirements(crocodileSubsystem);
     }
-    //overload autointke and set stopIntake to null
+
+    // overload autointke and set stopIntake to null
     public AutoIntakeCommand(CrocodileSubsystem crocodileSubsystem, double speed) {
         this(crocodileSubsystem, speed, null);
     }
-
 
     @Override
     public void initialize() {
@@ -35,27 +35,30 @@ public class AutoIntakeCommand extends CommandBase {
 
     @Override
     public boolean isFinished() {
-        //if outtaking, keep running motors until beam break hasn't been broken for 0.5 seconds
-        if(speed < 0){
-            if(crocodileSubsystem.getBeamBreak()){
+        // if outtaking, keep running motors until beam break hasn't been broken for 0.5
+        // seconds
+        if (speed < 0) {
+            if (crocodileSubsystem.getBeamBreak()) {
                 timer.start();
             }
-            if(timer.hasElapsed(0.5)){
+            if (timer.hasElapsed(0.5)) {
                 timer.stop();
                 timer.reset();
                 return true;
             }
         }
-        //otherwise, keep running motors until beam break has been broken for 0.5 seconds
-        else if(!debouncer.calculate(crocodileSubsystem.getBeamBreak())){
+        // otherwise, keep running motors until beam break has been broken for 0.5
+        // seconds
+        else if (!debouncer.calculate(crocodileSubsystem.getBeamBreak())) {
             return true;
         }
-        //if none of the above, return the value of stopIntake which is bound to a button, unless it is null
-        if(stopIntake != null){
+        // if none of the above, return the value of stopIntake which is bound to a
+        // button, unless it is null
+        if (stopIntake != null) {
             return stopIntake.getAsBoolean();
         }
         return false;
-        
+
     }
 
     @Override

--- a/src/main/java/frc/robot/commands/AutoIntakeCommand.java
+++ b/src/main/java/frc/robot/commands/AutoIntakeCommand.java
@@ -11,12 +11,14 @@ public class AutoIntakeCommand extends CommandBase {
     private final double speed;
     private final Timer timer;
     private final Debouncer debouncer;
+    private final BooleanSupplier stopIntake;
 
-    public AutoIntakeCommand(CrocodileSubsystem crocodileSubsystem, double speed) {
+    public AutoIntakeCommand(CrocodileSubsystem crocodileSubsystem, double speed, BooleanSupplier stopIntake) {
         this.crocodileSubsystem = crocodileSubsystem;
         this.speed = speed;
         debouncer = new Debouncer(0.5, DebounceType.kBoth);
         timer = new Timer();
+        this.stopIntake = stopIntake;
         addRequirements(crocodileSubsystem);
     }
 
@@ -42,7 +44,12 @@ public class AutoIntakeCommand extends CommandBase {
         else if(debouncer.calculate(crocodileSubsystem.getBeamBreak())){
             return true;
         }
+        //if none of the above, return the value of stopIntake which is bound to a button, unless it is null
+        if(stopIntake != null){
+            return stopIntake.getAsBoolean();
+        }
         return false;
+        
     }
 
     @Override


### PR DESCRIPTION
Overloaded auto intake command with a boolean supplier, can be bound to a button to stop auto intake if needed. If no boolean supplier is passed, it is set to null. Logic is added to handle that. 