### PR TITLE
Upgraded the bounds protection for the telescope

### DIFF
--- a/src/main/java/frc/robot/commands/DefaultCommands/TelescopeDefault.java
+++ b/src/main/java/frc/robot/commands/DefaultCommands/TelescopeDefault.java
@@ -5,6 +5,7 @@ import java.util.function.DoubleSupplier;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.TelescopeSubsystem;
+import frc.robot.subsystems.TelescopeSubsystem.TelescopeBoundState;
 
 public class TelescopeDefault extends CommandBase {
 
@@ -28,10 +29,12 @@ public class TelescopeDefault extends CommandBase {
         double joystickInput = joystickSupplier.getAsDouble();
 
         if (Math.abs(joystickInput) > 0.05) {
-            if (telescopeSubsystem.inBounds()) {
+            if (telescopeSubsystem.inBounds() == TelescopeBoundState.IN_BOUNDS) {
                 telescopeSubsystem.setSpeed(MathUtil.clamp(joystickInput, -0.3, 0.3));
-            } else {
+            } else if (telescopeSubsystem.inBounds() == TelescopeBoundState.OVER_UPPER_BOUND) {
                 telescopeSubsystem.setSpeed(MathUtil.clamp(joystickInput, -0.3, 0));
+            } else if (telescopeSubsystem.inBounds() == TelescopeBoundState.UNDER_LOWER_BOUND) {
+                telescopeSubsystem.setSpeed(MathUtil.clamp(joystickInput, 0, 0.3));
             }
         } else {
             telescopeSubsystem.setToCurrentPosition();

--- a/src/main/java/frc/robot/commands/TelescopeToPosition.java
+++ b/src/main/java/frc/robot/commands/TelescopeToPosition.java
@@ -1,5 +1,6 @@
 package frc.robot.commands;
 
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.TelescopeSubsystem;
 
@@ -12,6 +13,7 @@ public class TelescopeToPosition extends CommandBase {
 
     public TelescopeToPosition(TelescopeSubsystem telescopeSubsystem, double percent) {
         this.telescopeSubsystem = telescopeSubsystem;
+        percent = MathUtil.clamp(percent, telescopeSubsystem.LOWER_BOUND, telescopeSubsystem.UPPER_BOUND);
         this.percent = percent;
     }
 

--- a/src/main/java/frc/robot/commands/TelescopeToPosition.java
+++ b/src/main/java/frc/robot/commands/TelescopeToPosition.java
@@ -10,10 +10,10 @@ public class TelescopeToPosition extends CommandBase {
     // Setpoint to run the telescope to
     // In percent of maximum extension
     private final double percent;
-
+    
     public TelescopeToPosition(TelescopeSubsystem telescopeSubsystem, double percent) {
         this.telescopeSubsystem = telescopeSubsystem;
-        percent = MathUtil.clamp(percent, telescopeSubsystem.LOWER_BOUND, telescopeSubsystem.UPPER_BOUND);
+        percent = MathUtil.clamp(percent, 0.025, 0.9);
         this.percent = percent;
     }
 

--- a/src/main/java/frc/robot/subsystems/TelescopeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/TelescopeSubsystem.java
@@ -24,7 +24,17 @@ public class TelescopeSubsystem extends SubsystemBase {
     // F for telescope PID
     private static final double F_COEFF = 0;
     // The telecope cannot exceed these ticks
-    private static final int UPPER_BOUND = 97105;
+    public static final int UPPER_BOUND = 70000;
+    public static final int LOWER_BOUND = 1000;
+
+    public enum TelescopeBoundState {
+        // The telescope is within the bounds
+        IN_BOUNDS,
+        // The telescope is at the upper bound
+        OVER_UPPER_BOUND,
+        // The telescope is at the lower bound
+        UNDER_LOWER_BOUND
+    }
 
     // Telescope motor
     private final WPI_TalonFX telescopeMotor;
@@ -132,7 +142,13 @@ public class TelescopeSubsystem extends SubsystemBase {
     }
 
     // Returns true if the telescope is within its upper bound, false otherwise
-    public boolean inBounds() {
-        return getExtensionPercent() < 1;
+    public TelescopeBoundState inBounds() {
+        if (getCurrentPosition() > UPPER_BOUND) {
+            return TelescopeBoundState.OVER_UPPER_BOUND;
+        } else if (getCurrentPosition() < LOWER_BOUND) {
+            return TelescopeBoundState.UNDER_LOWER_BOUND;
+        } else {
+            return TelescopeBoundState.IN_BOUNDS;
+        }
     }
 }


### PR DESCRIPTION
We've got a new fun thing to account for with this telescope design. On the previous design, it didn't matter much if you went below the lower bound - the motor would just stall. On this design, we'll break the spring if we do that. So the bounds protection needs some help. This PR includes:
- A new enum (`TelescopeBoundState`) to track the state of the bounds of the telescope.
- Upgrades to the `inBounds()` function to return values from this enum
- Updated conditionals in `TelescopeDefault` so that if we are out of the upper bound, we can retract, and if we are under the lower bound, we can extend. This allows us to get back in bounds no matter what.
- Clamping the value of `TelescopeToPosition` so that it cannot go out of bounds