### PR TITLE
Added game piece enum to intake so we can have presets act depending on game piece

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -130,8 +130,7 @@ public class RobotContainer {
     mechController.y().onTrue(new RotatorToPosition(rotator, telescope, 200));
     mechController.x().onTrue(new TelescopeToPosition(telescope, 0.9));
     mechController.b().onTrue(new InstantCommand(() -> telescope.resetEncoder()));
-    driverController.y().onTrue(new AutoIntakeCommand(endEffector, 0.5));
-    driverController.x().onTrue(new AutoIntakeCommand(endEffector, -0.5));
+    driverController.y().onTrue(new AutoIntakeCommand(endEffector, 0.5, driverController.y()));
   }
 
   public void teleopInit() {

--- a/src/main/java/frc/robot/commands/AutoIntakeCommand.java
+++ b/src/main/java/frc/robot/commands/AutoIntakeCommand.java
@@ -16,20 +16,27 @@ public class AutoIntakeCommand extends CommandBase {
     private final BooleanSupplier stopIntake;
     private final GamePiece gamePiece;
 
-    public AutoIntakeCommand(CrocodileSubsystem crocodileSubsystem, double speed, BooleanSupplier stopIntake) {
+    public AutoIntakeCommand(CrocodileSubsystem crocodileSubsystem, double speed, BooleanSupplier stopIntake, GamePiece gamePiece) {
         this.crocodileSubsystem = crocodileSubsystem;
         this.speed = speed;
         debouncer = new Debouncer(0.5, DebounceType.kFalling);
         timer = new Timer();
         this.stopIntake = stopIntake;
+        crocodileSubsystem.setGamePiece(gamePiece);
         this.gamePiece = crocodileSubsystem.getGamePiece();
         addRequirements(crocodileSubsystem);
     }
 
-    // overload autointke and set stopIntake to null
-    public AutoIntakeCommand(CrocodileSubsystem crocodileSubsystem, double speed) {
-        this(crocodileSubsystem, speed, null);
+    // overload autointke and set stopIntake to null, use for auto
+    public AutoIntakeCommand(CrocodileSubsystem crocodileSubsystem, double speed, GamePiece gamePiece) {
+        this(crocodileSubsystem, speed, null, gamePiece);
     }
+
+    //overload autointake and set gamepiece to getGamePiece
+    public AutoIntakeCommand(CrocodileSubsystem crocodileSubsystem, double speed, BooleanSupplier stopIntake) {
+        this(crocodileSubsystem, speed, stopIntake, crocodileSubsystem.getGamePiece());
+    }
+
 
     @Override
     public void initialize() {

--- a/src/main/java/frc/robot/commands/AutoIntakeCommand.java
+++ b/src/main/java/frc/robot/commands/AutoIntakeCommand.java
@@ -6,6 +6,7 @@ import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.CrocodileSubsystem;
 import java.util.function.BooleanSupplier;
+import frc.robot.subsystems.CrocodileSubsystem.GamePiece;
 
 public class AutoIntakeCommand extends CommandBase {
     private final CrocodileSubsystem crocodileSubsystem;
@@ -13,6 +14,7 @@ public class AutoIntakeCommand extends CommandBase {
     private final Timer timer;
     private final Debouncer debouncer;
     private final BooleanSupplier stopIntake;
+    private final GamePiece gamePiece;
 
     public AutoIntakeCommand(CrocodileSubsystem crocodileSubsystem, double speed, BooleanSupplier stopIntake) {
         this.crocodileSubsystem = crocodileSubsystem;
@@ -20,6 +22,7 @@ public class AutoIntakeCommand extends CommandBase {
         debouncer = new Debouncer(0.5, DebounceType.kFalling);
         timer = new Timer();
         this.stopIntake = stopIntake;
+        this.gamePiece = crocodileSubsystem.getGamePiece();
         addRequirements(crocodileSubsystem);
     }
 
@@ -30,14 +33,21 @@ public class AutoIntakeCommand extends CommandBase {
 
     @Override
     public void initialize() {
-        crocodileSubsystem.setIntakeSpeed(speed);
+        //TODO: check if this is the right negation
+        if(gamePiece == GamePiece.CONE){
+            crocodileSubsystem.setIntakeSpeed(speed);
+        }
+        else{
+            crocodileSubsystem.setIntakeSpeed(-speed);
+        }
     }
 
     @Override
     public boolean isFinished() {
         // if outtaking, keep running motors until beam break hasn't been broken for 0.5
         // seconds
-        if (speed < 0) {
+        
+        if ((speed < 0 && gamePiece == GamePiece.CONE) || (speed > 0 && gamePiece == GamePiece.CUBE)) {
             if (crocodileSubsystem.getBeamBreak()) {
                 timer.start();
             }

--- a/src/main/java/frc/robot/commands/DefaultCommands/CrocodileDefaultCommand.java
+++ b/src/main/java/frc/robot/commands/DefaultCommands/CrocodileDefaultCommand.java
@@ -31,8 +31,13 @@ public class CrocodileDefaultCommand extends CommandBase {
     // Called every time the scheduler runs while the command is scheduled.
     @Override
     public void execute() {
-
-        subsystem.setIntakeSpeed(trigger.getAsDouble());
+        //TODO: check if this is the right negation
+        if(subsystem.getGamePiece() == CrocodileSubsystem.GamePiece.CONE){
+            subsystem.setIntakeSpeed(trigger.getAsDouble());
+        }
+        else{
+            subsystem.setIntakeSpeed(-trigger.getAsDouble());
+        }
         // sets rumble if beam break is broken for 0.5 seconds and is not already
         // rumbling
         if (!subsystem.getBeamBreak() && !beamBreakTracker) {

--- a/src/main/java/frc/robot/subsystems/CrocodileSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/CrocodileSubsystem.java
@@ -17,6 +17,7 @@ public class CrocodileSubsystem extends SubsystemBase {
     private final PIDController wristPID;
     private final DutyCycleEncoder wristEncoder;
     private final DigitalInput beamBreak;
+    private GamePiece gamePiece = GamePiece.CONE;
     //TODO: Tune PID
     private final double WRIST_kP = 1.0;
     private final double WRIST_kI = 0.0;
@@ -27,6 +28,11 @@ public class CrocodileSubsystem extends SubsystemBase {
 
     // Offset of the encoder. See diagram above for reference
     private final double ENCODER_OFFSET = 0.3;
+
+    public enum GamePiece {
+        CONE, 
+        CUBE
+    }
 
     public CrocodileSubsystem() {
         intake = new WPI_TalonFX(RobotMap.Crocodile.INTAKE);
@@ -68,6 +74,14 @@ public class CrocodileSubsystem extends SubsystemBase {
 
     public boolean getBeamBreak() {
         return beamBreak.get();
+    }
+    
+    public GamePiece getGamePiece() {
+        return gamePiece;
+    }
+
+    public void setGamePiece(GamePiece gamePiece) {
+        this.gamePiece = gamePiece;
     }
 
     @Override


### PR DESCRIPTION
Added a game piece enum to the intake subsystem. This can be set using a button on the second controller. We need this to intake cones vs cubes, since the intake has to spin different ways. Also, it can be used for presets for scoring and intaking. I also added some stuff to the existing commands that utilize the intake to reverse the intake for the cube, which I think is what we want, but will need to be tested.