### PR TITLE
Van Code from Clem for Game Piece Selection

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -115,7 +115,6 @@ public class RobotContainer {
         () -> (mechController.getRightTriggerAxis() - mechController.getLeftTriggerAxis()),
         (t) -> driverController.getHID().setRumble(RumbleType.kBothRumble, t)));
 
-
     autoChooser.setDefaultOption("CENTER Preload Park", new PreloadParkCenter(swerve, endEffector, rotator, telescope));
     autoChooser.addOption("RIGHT Preload + 1", new PreloadPlusOneRight(swerve, endEffector, rotator, telescope));
     autoChooser.addOption("LEFT Preload + 1", new PreloadPlusOneLeft(swerve, endEffector, rotator, telescope));
@@ -139,11 +138,13 @@ public class RobotContainer {
 
     zeroGyro.onTrue(new InstantCommand(() -> swerve.zeroGyro()));
 
-    mechController.a().onTrue(new PickupPresetSequence(telescope, rotator, endEffector, driverController.y(), () -> (endEffector.getGamePiece() == GamePiece.CONE ? true : false)));
+    mechController.a().onTrue(new PickupPresetSequence(telescope, rotator, endEffector, driverController.y(),
+        () -> endEffector.getGamePiece()));
     mechController.y().onTrue(new StowPresetSequence(telescope, rotator, endEffector));
     mechController.x().onTrue(new HighPresetSequence(telescope, rotator, endEffector,
-        () -> (driverController.getRightTriggerAxis() - driverController.getLeftTriggerAxis())));
-    mechController.b().onTrue(new MidPresetSequence(telescope, rotator, endEffector));
+        () -> (driverController.getRightTriggerAxis() - driverController.getLeftTriggerAxis()),
+        () -> endEffector.getGamePiece()));
+    mechController.b().onTrue(new MidPresetSequence(telescope, rotator, endEffector, () -> endEffector.getGamePiece()));
     mechController.povLeft().onTrue(new InstantCommand(() -> telescope.resetEncoder()));
     mechController.button(8).onTrue(new InstantCommand(() -> {
       endEffector.setGamePiece(GamePiece.CONE);
@@ -154,7 +155,8 @@ public class RobotContainer {
       candle.cube();
     }, endEffector));
     mechController.povDown()
-        .onTrue(new SubstationPickupPresetSequence(telescope, rotator, endEffector, driverController.y()));
+        .onTrue(new SubstationPickupPresetSequence(telescope, rotator, endEffector, driverController.y(),
+            () -> endEffector.getGamePiece()));
     driverController.y().onTrue(new AutoIntakeCommand(endEffector, 0.5, driverController.y()));
   }
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -138,8 +138,7 @@ public class RobotContainer {
 
     zeroGyro.onTrue(new InstantCommand(() -> swerve.zeroGyro()));
 
-    mechController.a().onTrue(new PickupPresetSequence(telescope, rotator, endEffector, driverController.y(),
-        () -> endEffector.getGamePiece()));
+    mechController.a().onTrue(new PickupPresetSequence(telescope, rotator, endEffector, driverController.y()));
     mechController.y().onTrue(new StowPresetSequence(telescope, rotator, endEffector));
     mechController.x().onTrue(new HighPresetSequence(telescope, rotator, endEffector,
         () -> (driverController.getRightTriggerAxis() - driverController.getLeftTriggerAxis()),

--- a/src/main/java/frc/robot/commands/AutoIntakeCommand.java
+++ b/src/main/java/frc/robot/commands/AutoIntakeCommand.java
@@ -6,6 +6,8 @@ import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.CrocodileSubsystem;
 import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+
 import frc.robot.subsystems.CrocodileSubsystem.GamePiece;
 
 public class AutoIntakeCommand extends CommandBase {
@@ -19,13 +21,13 @@ public class AutoIntakeCommand extends CommandBase {
     private boolean wasCancelled = false;
 
     public AutoIntakeCommand(CrocodileSubsystem crocodileSubsystem, double speed,
-            BooleanSupplier stopIntake, GamePiece gamePiece) {
+            BooleanSupplier stopIntake, Supplier<GamePiece> gamePiece) {
         this.crocodileSubsystem = crocodileSubsystem;
         this.speed = speed;
         debouncer = new Debouncer(0.5, DebounceType.kFalling);
         timer = new Timer();
         this.stopIntake = stopIntake;
-        crocodileSubsystem.setGamePiece(gamePiece);
+        crocodileSubsystem.setGamePiece(gamePiece.get());
         this.gamePiece = crocodileSubsystem.getGamePiece();
         addRequirements(crocodileSubsystem);
     }
@@ -33,13 +35,13 @@ public class AutoIntakeCommand extends CommandBase {
     // overload autointke and set stopIntake to null, use for auto
     public AutoIntakeCommand(CrocodileSubsystem crocodileSubsystem, double speed,
             GamePiece gamePiece) {
-        this(crocodileSubsystem, speed, null, gamePiece);
+        this(crocodileSubsystem, speed, null, () -> gamePiece);
     }
 
     // overload autointake and set gamepiece to getGamePiece
-    public AutoIntakeCommand(CrocodileSubsystem crocodileSubsystem,  double speed,
+    public AutoIntakeCommand(CrocodileSubsystem crocodileSubsystem, double speed,
             BooleanSupplier stopIntake) {
-        this(crocodileSubsystem, speed, stopIntake, crocodileSubsystem.getGamePiece());
+        this(crocodileSubsystem, speed, stopIntake, () -> crocodileSubsystem.getGamePiece());
     }
 
     @Override

--- a/src/main/java/frc/robot/commands/Autos/PreloadParkCenter.java
+++ b/src/main/java/frc/robot/commands/Autos/PreloadParkCenter.java
@@ -21,6 +21,7 @@ import frc.robot.commands.Presets.StowPresetSequence;
 import frc.robot.subsystems.CrocodileSubsystem;
 import frc.robot.subsystems.RotatorSubsystem;
 import frc.robot.subsystems.TelescopeSubsystem;
+import frc.robot.subsystems.CrocodileSubsystem.GamePiece;
 import frc.robot.subsystems.Swerve.DrivebaseSubsystem;
 
 public class PreloadParkCenter extends SequentialCommandGroup {
@@ -42,8 +43,8 @@ public class PreloadParkCenter extends SequentialCommandGroup {
     this.defaultConfig = new TrajectoryConfig(SharedConstants.AutoConstants.k_MAX_SPEED_MPS,
         SharedConstants.AutoConstants.k_MAX_ACCEL_MPS_SQUARED);
     addCommands(
-        new HighPresetSequence(telescope, rotator, croc, null),
-        new HighPresetSequence(telescope, rotator, croc, null),
+        new HighPresetSequence(telescope, rotator, croc, null, () ->GamePiece.CONE),
+        new HighPresetSequence(telescope, rotator, croc, null, () ->GamePiece.CONE),
         new InstantCommand(()->croc.setIntakeSpeed(-1)),
         new WaitCommand(0.25),
         new InstantCommand(()->croc.setIntakeSpeed(0)),

--- a/src/main/java/frc/robot/commands/Autos/PreloadPlusOneLeft.java
+++ b/src/main/java/frc/robot/commands/Autos/PreloadPlusOneLeft.java
@@ -21,6 +21,7 @@ import frc.robot.commands.Presets.StowPresetSequence;
 import frc.robot.subsystems.CrocodileSubsystem;
 import frc.robot.subsystems.RotatorSubsystem;
 import frc.robot.subsystems.TelescopeSubsystem;
+import frc.robot.subsystems.CrocodileSubsystem.GamePiece;
 import frc.robot.subsystems.Swerve.DrivebaseSubsystem;
 
 public class PreloadPlusOneLeft extends SequentialCommandGroup {
@@ -42,7 +43,7 @@ public class PreloadPlusOneLeft extends SequentialCommandGroup {
     this.defaultConfig = new TrajectoryConfig(SharedConstants.AutoConstants.k_MAX_SPEED_MPS,
         SharedConstants.AutoConstants.k_MAX_ACCEL_MPS_SQUARED);
     addCommands(
-        new HighPresetSequence(telescope, rotator, croc, null),
+        new HighPresetSequence(telescope, rotator, croc, null, () ->GamePiece.CONE),
         new InstantCommand(()->croc.setIntakeSpeed(-1)),
         new WaitCommand(0.25),
         new InstantCommand(()->croc.setIntakeSpeed(0)),
@@ -52,7 +53,7 @@ public class PreloadPlusOneLeft extends SequentialCommandGroup {
         ),
         new StowPresetSequence(telescope, rotator, croc),
         new SwerveTrajectoryFollowCommand(driveBase, "preloadPlusOneLeft2", defaultConfig),
-        new HighPresetSequence(telescope, rotator, croc, null),
+        new HighPresetSequence(telescope, rotator, croc, null, () ->GamePiece.CONE),
         new InstantCommand(()->croc.setIntakeSpeed(-1)),
         new WaitCommand(0.25),
         new StowPresetSequence(telescope, rotator, croc)

--- a/src/main/java/frc/robot/commands/Autos/PreloadPlusOneRight.java
+++ b/src/main/java/frc/robot/commands/Autos/PreloadPlusOneRight.java
@@ -21,6 +21,7 @@ import frc.robot.commands.Presets.StowPresetSequence;
 import frc.robot.subsystems.CrocodileSubsystem;
 import frc.robot.subsystems.RotatorSubsystem;
 import frc.robot.subsystems.TelescopeSubsystem;
+import frc.robot.subsystems.CrocodileSubsystem.GamePiece;
 import frc.robot.subsystems.Swerve.DrivebaseSubsystem;
 
 public class PreloadPlusOneRight extends SequentialCommandGroup {
@@ -42,7 +43,7 @@ public class PreloadPlusOneRight extends SequentialCommandGroup {
     this.defaultConfig = new TrajectoryConfig(SharedConstants.AutoConstants.k_MAX_SPEED_MPS,
         SharedConstants.AutoConstants.k_MAX_ACCEL_MPS_SQUARED);
     addCommands(
-        new HighPresetSequence(telescope, rotator, croc, null),
+        new HighPresetSequence(telescope, rotator, croc, null, () ->GamePiece.CONE),
         new InstantCommand(()->croc.setIntakeSpeed(-1)),
         new WaitCommand(0.25),
         new InstantCommand(()->croc.setIntakeSpeed(0)),
@@ -52,7 +53,7 @@ public class PreloadPlusOneRight extends SequentialCommandGroup {
         ),
         new StowPresetSequence(telescope, rotator, croc),
         new SwerveTrajectoryFollowCommand(driveBase, "preloadPlusOneRight2", defaultConfig),
-        new HighPresetSequence(telescope, rotator, croc, null),
+        new HighPresetSequence(telescope, rotator, croc, null, () ->GamePiece.CONE),
         new InstantCommand(()->croc.setIntakeSpeed(-1)),
         new WaitCommand(0.25),
         new StowPresetSequence(telescope, rotator, croc)

--- a/src/main/java/frc/robot/commands/Presets/HighPresetSequence.java
+++ b/src/main/java/frc/robot/commands/Presets/HighPresetSequence.java
@@ -3,6 +3,7 @@ package frc.robot.commands.Presets;
 import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
 
+import edu.wpi.first.wpilibj2.command.ConditionalCommand;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
@@ -31,16 +32,12 @@ public class HighPresetSequence extends SequentialCommandGroup {
         addCommands(
                 new InstantCommand(() -> crocodile.setIntakeSpeed(0.25 * multiplier)),
                 new RotatorToPosition(rotator, telescope, RotatorPosition.HIGH_SCORE).withTimeout(2),
-                new TelescopeToPosition(telescope, TelescopePosition.HIGH_SCORE).withTimeout(2));
-        switch (gamePiece.get()) {
-            case CONE:
-                addCommands(
-                        crocodile.setWristToPositionCommand(WristPosition.CONE_SCORE).withTimeout(2));
-                break;
-            case CUBE:
-                addCommands(
-                        crocodile.setWristToPositionCommand(WristPosition.CUBE_SCORE).withTimeout(2));
-                break;
-        }
+                new TelescopeToPosition(telescope, TelescopePosition.HIGH_SCORE).withTimeout(2),
+                new ConditionalCommand(
+                    crocodile.setWristToPositionCommand(WristPosition.CONE_SCORE), 
+                    crocodile.setWristToPositionCommand(WristPosition.CUBE_SCORE), 
+                    () -> crocodile.getGamePiece() == GamePiece.CONE)
+        );
+        
     }
 }

--- a/src/main/java/frc/robot/commands/Presets/HighPresetSequence.java
+++ b/src/main/java/frc/robot/commands/Presets/HighPresetSequence.java
@@ -19,18 +19,15 @@ import frc.robot.subsystems.TelescopeSubsystem.TelescopePosition;
 
 public class HighPresetSequence extends SequentialCommandGroup {
     private DoubleSupplier intake;
-    private double multiplier = 1;
 
     public HighPresetSequence(TelescopeSubsystem telescope, RotatorSubsystem rotator, CrocodileSubsystem crocodile,
             DoubleSupplier intake, Supplier<GamePiece> gamePiece) {
         this.intake = intake;
         addRequirements(rotator, telescope, crocodile);
-
-        if (gamePiece.get() == GamePiece.CUBE) {
-            multiplier = -1;
-        }
+        //thank you @mikemag for this
+        DoubleSupplier multiplier = () -> gamePiece.get() == GamePiece.CONE ? 1 : -1;
         addCommands(
-                new InstantCommand(() -> crocodile.setIntakeSpeed(0.25 * multiplier)),
+                new InstantCommand(() -> crocodile.setIntakeSpeed(0.25 * multiplier.getAsDouble())),
                 new RotatorToPosition(rotator, telescope, RotatorPosition.HIGH_SCORE).withTimeout(2),
                 new TelescopeToPosition(telescope, TelescopePosition.HIGH_SCORE).withTimeout(2),
                 new ConditionalCommand(

--- a/src/main/java/frc/robot/commands/Presets/HighPresetSequence.java
+++ b/src/main/java/frc/robot/commands/Presets/HighPresetSequence.java
@@ -1,6 +1,7 @@
 package frc.robot.commands.Presets;
 
 import java.util.function.DoubleSupplier;
+import java.util.function.Supplier;
 
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
@@ -17,20 +18,29 @@ import frc.robot.subsystems.TelescopeSubsystem.TelescopePosition;
 
 public class HighPresetSequence extends SequentialCommandGroup {
     private DoubleSupplier intake;
-    private double multiplier = 1; 
-    public HighPresetSequence(TelescopeSubsystem telescope, RotatorSubsystem rotator, CrocodileSubsystem crocodile, DoubleSupplier intake) {
+    private double multiplier = 1;
+
+    public HighPresetSequence(TelescopeSubsystem telescope, RotatorSubsystem rotator, CrocodileSubsystem crocodile,
+            DoubleSupplier intake, Supplier<GamePiece> gamePiece) {
         this.intake = intake;
-        addRequirements(rotator,telescope,crocodile);
-        
-        if(crocodile.getGamePiece() == GamePiece.CUBE){
+        addRequirements(rotator, telescope, crocodile);
+
+        if (gamePiece.get() == GamePiece.CUBE) {
             multiplier = -1;
         }
         addCommands(
-            new InstantCommand(()->crocodile.setIntakeSpeed(0.25 * multiplier)),
-            new RotatorToPosition(rotator, telescope, RotatorPosition.HIGH_SCORE).withTimeout(2),
-            new TelescopeToPosition(telescope, TelescopePosition.HIGH_SCORE).withTimeout(2),
-            crocodile.setWristToPositionCommand(WristPosition.CONE_SCORE).withTimeout(2)
-            
-        );
+                new InstantCommand(() -> crocodile.setIntakeSpeed(0.25 * multiplier)),
+                new RotatorToPosition(rotator, telescope, RotatorPosition.HIGH_SCORE).withTimeout(2),
+                new TelescopeToPosition(telescope, TelescopePosition.HIGH_SCORE).withTimeout(2));
+        switch (gamePiece.get()) {
+            case CONE:
+                addCommands(
+                        crocodile.setWristToPositionCommand(WristPosition.CONE_SCORE).withTimeout(2));
+                break;
+            case CUBE:
+                addCommands(
+                        crocodile.setWristToPositionCommand(WristPosition.CUBE_SCORE).withTimeout(2));
+                break;
+        }
     }
 }

--- a/src/main/java/frc/robot/commands/Presets/MidPresetSequence.java
+++ b/src/main/java/frc/robot/commands/Presets/MidPresetSequence.java
@@ -2,6 +2,7 @@ package frc.robot.commands.Presets;
 
 import java.util.function.Supplier;
 
+import edu.wpi.first.wpilibj2.command.ConditionalCommand;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.robot.commands.RotatorToPosition;
@@ -18,16 +19,10 @@ public class MidPresetSequence extends SequentialCommandGroup {
             Supplier<GamePiece> gamePiece) {
         addRequirements(rotator, telescope, crocodile);
         addCommands(
-                new RotatorToPosition(rotator, telescope, RotatorPosition.HIGH_SCORE).withTimeout(2));
-        switch (gamePiece.get()) {
-            case CONE:
-                addCommands(
-                        crocodile.setWristToPositionCommand(WristPosition.CONE_SCORE).withTimeout(2));
-                break;
-            case CUBE:
-                addCommands(
-                        crocodile.setWristToPositionCommand(WristPosition.CUBE_SCORE).withTimeout(2));
-                break;
-        }
+                new RotatorToPosition(rotator, telescope, RotatorPosition.HIGH_SCORE).withTimeout(2),
+                new ConditionalCommand(
+                    crocodile.setWristToPositionCommand(WristPosition.CONE_SCORE), 
+                    crocodile.setWristToPositionCommand(WristPosition.CUBE_SCORE), 
+                    () -> crocodile.getGamePiece() == GamePiece.CONE));
     }
 }

--- a/src/main/java/frc/robot/commands/Presets/MidPresetSequence.java
+++ b/src/main/java/frc/robot/commands/Presets/MidPresetSequence.java
@@ -1,5 +1,7 @@
 package frc.robot.commands.Presets;
 
+import java.util.function.Supplier;
+
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.robot.commands.RotatorToPosition;
@@ -7,16 +9,25 @@ import frc.robot.commands.TelescopeToPosition;
 import frc.robot.subsystems.CrocodileSubsystem;
 import frc.robot.subsystems.RotatorSubsystem;
 import frc.robot.subsystems.TelescopeSubsystem;
+import frc.robot.subsystems.CrocodileSubsystem.GamePiece;
 import frc.robot.subsystems.CrocodileSubsystem.WristPosition;
 import frc.robot.subsystems.RotatorSubsystem.RotatorPosition;
 
 public class MidPresetSequence extends SequentialCommandGroup {
-    public MidPresetSequence(TelescopeSubsystem telescope, RotatorSubsystem rotator, CrocodileSubsystem crocodile) {
-        addRequirements(rotator,telescope,crocodile);
+    public MidPresetSequence(TelescopeSubsystem telescope, RotatorSubsystem rotator, CrocodileSubsystem crocodile,
+            Supplier<GamePiece> gamePiece) {
+        addRequirements(rotator, telescope, crocodile);
         addCommands(
-            new RotatorToPosition(rotator, telescope, RotatorPosition.HIGH_SCORE).withTimeout(2),
-            crocodile.setWristToPositionCommand(WristPosition.CONE_SCORE).withTimeout(2)
-            // new InstantCommand(()->crocodile.openChomper())
-        );
+                new RotatorToPosition(rotator, telescope, RotatorPosition.HIGH_SCORE).withTimeout(2));
+        switch (gamePiece.get()) {
+            case CONE:
+                addCommands(
+                        crocodile.setWristToPositionCommand(WristPosition.CONE_SCORE).withTimeout(2));
+                break;
+            case CUBE:
+                addCommands(
+                        crocodile.setWristToPositionCommand(WristPosition.CUBE_SCORE).withTimeout(2));
+                break;
+        }
     }
 }

--- a/src/main/java/frc/robot/commands/Presets/PickupPresetSequence.java
+++ b/src/main/java/frc/robot/commands/Presets/PickupPresetSequence.java
@@ -3,6 +3,7 @@ package frc.robot.commands.Presets;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
+import edu.wpi.first.wpilibj2.command.ConditionalCommand;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.robot.commands.AutoIntakeCommand;
@@ -18,26 +19,15 @@ import frc.robot.subsystems.TelescopeSubsystem.TelescopePosition;
 
 public class PickupPresetSequence extends SequentialCommandGroup {
     public PickupPresetSequence(TelescopeSubsystem telescope, RotatorSubsystem rotator, CrocodileSubsystem crocodile,
-            BooleanSupplier button, Supplier<GamePiece> gamePieice) {
-        addRequirements(telescope, rotator, crocodile);
-        addCommands(
-                new TelescopeToPosition(telescope, TelescopePosition.GROUND_PICKUP).withTimeout(2),
-                new RotatorToPosition(rotator, telescope, RotatorPosition.GROUND_PICKUP).withTimeout(2));
-        if (gamePieice.get() == GamePiece.CONE) {
-            addCommands(crocodile.setWristToPositionCommand(WristPosition.CONE_PICKUP).withTimeout(2));
-        } else {
-            addCommands(crocodile.setWristToPositionCommand(WristPosition.CUBE_PICKUP).withTimeout(2));
-        }
-        addCommands(new AutoIntakeCommand(crocodile, 1, button));
-    }
-
-    public PickupPresetSequence(TelescopeSubsystem telescope, RotatorSubsystem rotator, CrocodileSubsystem crocodile,
             BooleanSupplier button) {
         addRequirements(telescope, rotator, crocodile);
         addCommands(
                 new TelescopeToPosition(telescope, TelescopePosition.GROUND_PICKUP).withTimeout(2),
-                new RotatorToPosition(rotator, telescope, RotatorPosition.GROUND_PICKUP).withTimeout(2));
-        addCommands(crocodile.setWristToPositionCommand(WristPosition.CONE_PICKUP).withTimeout(2));
-        addCommands(new AutoIntakeCommand(crocodile, 1, button));
+                new RotatorToPosition(rotator, telescope, RotatorPosition.GROUND_PICKUP).withTimeout(2),
+                new ConditionalCommand(
+                    crocodile.setWristToPositionCommand(WristPosition.CONE_PICKUP), 
+                    crocodile.setWristToPositionCommand(WristPosition.CUBE_PICKUP), 
+                    () -> crocodile.getGamePiece() == GamePiece.CONE),
+                new AutoIntakeCommand(crocodile, 1, button));
     }
 }

--- a/src/main/java/frc/robot/commands/Presets/PickupPresetSequence.java
+++ b/src/main/java/frc/robot/commands/Presets/PickupPresetSequence.java
@@ -1,6 +1,7 @@
 package frc.robot.commands.Presets;
 
 import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
 
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
@@ -16,26 +17,26 @@ import frc.robot.subsystems.RotatorSubsystem.RotatorPosition;
 import frc.robot.subsystems.TelescopeSubsystem.TelescopePosition;
 
 public class PickupPresetSequence extends SequentialCommandGroup {
-    public PickupPresetSequence(TelescopeSubsystem telescope, RotatorSubsystem rotator, CrocodileSubsystem crocodile, BooleanSupplier button, BooleanSupplier gamePieice) {
-        addRequirements(telescope,rotator,crocodile);
+    public PickupPresetSequence(TelescopeSubsystem telescope, RotatorSubsystem rotator, CrocodileSubsystem crocodile,
+            BooleanSupplier button, Supplier<GamePiece> gamePieice) {
+        addRequirements(telescope, rotator, crocodile);
         addCommands(
-            new TelescopeToPosition(telescope, TelescopePosition.GROUND_PICKUP).withTimeout(2),
-            new RotatorToPosition(rotator, telescope, RotatorPosition.GROUND_PICKUP).withTimeout(2)
-        );
-        if (gamePieice.getAsBoolean()){
+                new TelescopeToPosition(telescope, TelescopePosition.GROUND_PICKUP).withTimeout(2),
+                new RotatorToPosition(rotator, telescope, RotatorPosition.GROUND_PICKUP).withTimeout(2));
+        if (gamePieice.get() == GamePiece.CONE) {
             addCommands(crocodile.setWristToPositionCommand(WristPosition.CONE_PICKUP).withTimeout(2));
-        }
-        else {
+        } else {
             addCommands(crocodile.setWristToPositionCommand(WristPosition.CUBE_PICKUP).withTimeout(2));
         }
         addCommands(new AutoIntakeCommand(crocodile, 1, button));
     }
-    public PickupPresetSequence(TelescopeSubsystem telescope, RotatorSubsystem rotator, CrocodileSubsystem crocodile, BooleanSupplier button) {
-        addRequirements(telescope,rotator,crocodile);
+
+    public PickupPresetSequence(TelescopeSubsystem telescope, RotatorSubsystem rotator, CrocodileSubsystem crocodile,
+            BooleanSupplier button) {
+        addRequirements(telescope, rotator, crocodile);
         addCommands(
-            new TelescopeToPosition(telescope, TelescopePosition.GROUND_PICKUP).withTimeout(2),
-            new RotatorToPosition(rotator, telescope, RotatorPosition.GROUND_PICKUP).withTimeout(2)
-        );
+                new TelescopeToPosition(telescope, TelescopePosition.GROUND_PICKUP).withTimeout(2),
+                new RotatorToPosition(rotator, telescope, RotatorPosition.GROUND_PICKUP).withTimeout(2));
         addCommands(crocodile.setWristToPositionCommand(WristPosition.CONE_PICKUP).withTimeout(2));
         addCommands(new AutoIntakeCommand(crocodile, 1, button));
     }

--- a/src/main/java/frc/robot/commands/Presets/StowPresetSequence.java
+++ b/src/main/java/frc/robot/commands/Presets/StowPresetSequence.java
@@ -16,11 +16,10 @@ import frc.robot.subsystems.TelescopeSubsystem.TelescopePosition;
 
 public class StowPresetSequence extends SequentialCommandGroup {
     public StowPresetSequence(TelescopeSubsystem telescope, RotatorSubsystem rotator, CrocodileSubsystem crocodile) {
-        addRequirements(telescope,rotator,crocodile);
+        addRequirements(telescope, rotator, crocodile);
         addCommands(
-            new TelescopeToPosition(telescope, TelescopePosition.RETRACTED).withTimeout(2),
-            new RotatorToPosition(rotator, telescope, 90).withTimeout(2),
-            crocodile.setWristToPositionCommand(WristPosition.CONE_SCORE).withTimeout(2)
-        );
+                new TelescopeToPosition(telescope, TelescopePosition.RETRACTED).withTimeout(2),
+                new RotatorToPosition(rotator, telescope, 90).withTimeout(2),
+                crocodile.setWristToPositionCommand(WristPosition.CONE_SCORE).withTimeout(2));
     }
 }

--- a/src/main/java/frc/robot/commands/Presets/SubstationPickupPresetSequence.java
+++ b/src/main/java/frc/robot/commands/Presets/SubstationPickupPresetSequence.java
@@ -3,6 +3,7 @@ package frc.robot.commands.Presets;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
+import edu.wpi.first.wpilibj2.command.ConditionalCommand;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.robot.commands.AutoIntakeCommand;
@@ -22,17 +23,11 @@ public class SubstationPickupPresetSequence extends SequentialCommandGroup {
         addRequirements(telescope, rotator, crocodile);
         addCommands(
                 new RotatorToPosition(rotator, telescope, RotatorPosition.SHELF_PICKUP).withTimeout(2),
-                new TelescopeToPosition(telescope, TelescopePosition.SHELF_PICKUP).withTimeout(2));
-        switch (gamePiece.get()) {
-            case CONE:
-                addCommands(
-                        crocodile.setWristToPositionCommand(WristPosition.CONE_SHELF).withTimeout(2));
-                break;
-            case CUBE:
-                addCommands(
-                        crocodile.setWristToPositionCommand(WristPosition.CUBE_SHELF).withTimeout(2));
-                break;
-        }
-        addCommands(new AutoIntakeCommand(crocodile, 1, button));
+                new TelescopeToPosition(telescope, TelescopePosition.SHELF_PICKUP).withTimeout(2),
+                new ConditionalCommand(
+                    crocodile.setWristToPositionCommand(WristPosition.CONE_SCORE), 
+                    crocodile.setWristToPositionCommand(WristPosition.CUBE_SCORE), 
+                    () -> crocodile.getGamePiece() == GamePiece.CONE),
+                new AutoIntakeCommand(crocodile, 1, button));
     }
 }

--- a/src/main/java/frc/robot/commands/Presets/SubstationPickupPresetSequence.java
+++ b/src/main/java/frc/robot/commands/Presets/SubstationPickupPresetSequence.java
@@ -1,6 +1,7 @@
 package frc.robot.commands.Presets;
 
 import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
 
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
@@ -17,12 +18,21 @@ import frc.robot.subsystems.TelescopeSubsystem.TelescopePosition;
 
 public class SubstationPickupPresetSequence extends SequentialCommandGroup {
     public SubstationPickupPresetSequence(TelescopeSubsystem telescope, RotatorSubsystem rotator,
-            CrocodileSubsystem crocodile, BooleanSupplier button) {
+            CrocodileSubsystem crocodile, BooleanSupplier button, Supplier<GamePiece> gamePiece) {
         addRequirements(telescope, rotator, crocodile);
         addCommands(
                 new RotatorToPosition(rotator, telescope, RotatorPosition.SHELF_PICKUP).withTimeout(2),
-                new TelescopeToPosition(telescope, TelescopePosition.SHELF_PICKUP).withTimeout(2),
-                crocodile.setWristToPositionCommand(WristPosition.CONE_SHELF).withTimeout(2),
-                new AutoIntakeCommand(crocodile, 1, button));
+                new TelescopeToPosition(telescope, TelescopePosition.SHELF_PICKUP).withTimeout(2));
+        switch (gamePiece.get()) {
+            case CONE:
+                addCommands(
+                        crocodile.setWristToPositionCommand(WristPosition.CONE_SHELF).withTimeout(2));
+                break;
+            case CUBE:
+                addCommands(
+                        crocodile.setWristToPositionCommand(WristPosition.CUBE_SHELF).withTimeout(2));
+                break;
+        }
+        addCommands(new AutoIntakeCommand(crocodile, 1, button));
     }
 }

--- a/src/main/java/frc/robot/commands/ReverseSwerveTrajectoryFollowCommand.java
+++ b/src/main/java/frc/robot/commands/ReverseSwerveTrajectoryFollowCommand.java
@@ -25,10 +25,10 @@ import frc.robot.subsystems.Swerve.DrivebaseSubsystem;
  */
 public class ReverseSwerveTrajectoryFollowCommand extends SwerveTrajectoryFollowCommand {
 
-    public ReverseSwerveTrajectoryFollowCommand(DrivebaseSubsystem drivetrain, String pathFilename, TrajectoryConfig config,
-    boolean isInitial) {
+    public ReverseSwerveTrajectoryFollowCommand(DrivebaseSubsystem drivetrain, String pathFilename,
+            TrajectoryConfig config,
+            boolean isInitial) {
         super(drivetrain, pathFilename, config, true, isInitial);
     }
-
 
 }


### PR DESCRIPTION
I *think* this should work. I've gone through and changed references from just a bare gamepiece and `getGamePiece()` to a Supplier<GamePiece>. AFAIK this should do what we want, and in less lines than our other solution. I have also added switch case for cubes where needed.

Nobody is allowed to talk about the spelling of the branch name.