### PR TITLE
Implemented Path Mirror Based On Alliance

### DIFF
--- a/src/main/java/frc/robot/commands/SwerveTrajectoryFollowCommand.java
+++ b/src/main/java/frc/robot/commands/SwerveTrajectoryFollowCommand.java
@@ -13,6 +13,7 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.trajectory.Trajectory;
 import edu.wpi.first.math.trajectory.TrajectoryConfig;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.Swerve.DrivebaseSubsystem;
@@ -42,8 +43,9 @@ public class SwerveTrajectoryFollowCommand extends CommandBase {
         this.drivetrain = drivetrain;
         addRequirements(drivetrain);
 
-        PathPlannerTrajectory ppTrajectory = PathPlanner.loadPath(pathFilename, config.getMaxVelocity(),
-                config.getMaxAcceleration(), isReversed);
+        PathPlannerTrajectory ppTrajectory = PathPlannerTrajectory
+                .transformTrajectoryForAlliance(PathPlanner.loadPath(pathFilename, config.getMaxVelocity(),
+                        config.getMaxAcceleration(), isReversed), DriverStation.getAlliance());
         this.trajectory = ppTrajectory;
 
         if (isInitial) {


### PR DESCRIPTION
Implemented path mirroring based on alliance. Done in init of the command so that it gets the driver station color on init rather than in the constructor and mirrors based on that value. All paths are made on the blue side just like path planner suggests to mirror them correctly.