### PR TITLE
Clem's van code for a passive intake system

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -139,11 +139,16 @@ public class RobotContainer {
     zeroGyro.onTrue(new InstantCommand(() -> swerve.zeroGyro()));
 
     mechController.a().onTrue(new PickupPresetSequence(telescope, rotator, endEffector, driverController.y()));
-    mechController.y().onTrue(new StowPresetSequence(telescope, rotator, endEffector));
+    mechController.y()
+        .onTrue(new StowPresetSequence(telescope, rotator, endEffector,
+            () -> (driverController.getRightTriggerAxis() - driverController.getLeftTriggerAxis()),
+            () -> endEffector.getGamePiece()));
     mechController.x().onTrue(new HighPresetSequence(telescope, rotator, endEffector,
         () -> (driverController.getRightTriggerAxis() - driverController.getLeftTriggerAxis()),
         () -> endEffector.getGamePiece()));
-    mechController.b().onTrue(new MidPresetSequence(telescope, rotator, endEffector, () -> endEffector.getGamePiece()));
+    mechController.b().onTrue(new MidPresetSequence(telescope, rotator, endEffector,
+        () -> (driverController.getRightTriggerAxis() - driverController.getLeftTriggerAxis()),
+        () -> endEffector.getGamePiece()));
     mechController.povLeft().onTrue(new InstantCommand(() -> telescope.resetEncoder()));
     mechController.button(8).onTrue(new InstantCommand(() -> {
       endEffector.setGamePiece(GamePiece.CONE);

--- a/src/main/java/frc/robot/commands/AutoIntakeCommand.java
+++ b/src/main/java/frc/robot/commands/AutoIntakeCommand.java
@@ -6,8 +6,6 @@ import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.CrocodileSubsystem;
 import java.util.function.BooleanSupplier;
-import java.util.function.Supplier;
-
 import frc.robot.subsystems.CrocodileSubsystem.GamePiece;
 
 public class AutoIntakeCommand extends CommandBase {
@@ -21,13 +19,13 @@ public class AutoIntakeCommand extends CommandBase {
     private boolean wasCancelled = false;
 
     public AutoIntakeCommand(CrocodileSubsystem crocodileSubsystem, double speed,
-            BooleanSupplier stopIntake, Supplier<GamePiece> gamePiece) {
+            BooleanSupplier stopIntake, GamePiece gamePiece) {
         this.crocodileSubsystem = crocodileSubsystem;
         this.speed = speed;
         debouncer = new Debouncer(0.5, DebounceType.kFalling);
         timer = new Timer();
         this.stopIntake = stopIntake;
-        crocodileSubsystem.setGamePiece(gamePiece.get());
+        crocodileSubsystem.setGamePiece(gamePiece);
         this.gamePiece = crocodileSubsystem.getGamePiece();
         addRequirements(crocodileSubsystem);
     }
@@ -35,31 +33,34 @@ public class AutoIntakeCommand extends CommandBase {
     // overload autointke and set stopIntake to null, use for auto
     public AutoIntakeCommand(CrocodileSubsystem crocodileSubsystem, double speed,
             GamePiece gamePiece) {
-        this(crocodileSubsystem, speed, null, () -> gamePiece);
+        this(crocodileSubsystem, speed, null, gamePiece);
     }
 
     // overload autointake and set gamepiece to getGamePiece
-    public AutoIntakeCommand(CrocodileSubsystem crocodileSubsystem, double speed,
+    public AutoIntakeCommand(CrocodileSubsystem crocodileSubsystem,  double speed,
             BooleanSupplier stopIntake) {
-        this(crocodileSubsystem, speed, stopIntake, () -> crocodileSubsystem.getGamePiece());
+        this(crocodileSubsystem, speed, stopIntake, crocodileSubsystem.getGamePiece());
     }
 
     @Override
     public void initialize() {
         // TODO: check if this is the right negation
-        if (gamePiece == GamePiece.CONE) {
+        if (crocodileSubsystem.getGamePiece() == GamePiece.CONE) {
             crocodileSubsystem.setIntakeSpeed(speed);
         } else {
             crocodileSubsystem.setIntakeSpeed(-speed);
         }
     }
+    @Override
+    public void execute(){
 
+    }
     @Override
     public boolean isFinished() {
         // if outtaking, keep running motors until beam break hasn't been broken for 0.5
         // seconds
 
-        if ((speed < 0 && gamePiece == GamePiece.CONE) || (speed > 0 && gamePiece == GamePiece.CUBE)) {
+        if ((speed < 0 && crocodileSubsystem.getGamePiece() == GamePiece.CONE) || (speed > 0 && gamePiece == GamePiece.CUBE)) {
             if (crocodileSubsystem.getBeamBreak()) {
                 timer.start();
             }

--- a/src/main/java/frc/robot/commands/Autos/PreloadParkCenter.java
+++ b/src/main/java/frc/robot/commands/Autos/PreloadParkCenter.java
@@ -43,44 +43,43 @@ public class PreloadParkCenter extends SequentialCommandGroup {
     this.defaultConfig = new TrajectoryConfig(SharedConstants.AutoConstants.k_MAX_SPEED_MPS,
         SharedConstants.AutoConstants.k_MAX_ACCEL_MPS_SQUARED);
     addCommands(
-        new HighPresetSequence(telescope, rotator, croc, null, () ->GamePiece.CONE),
-        new HighPresetSequence(telescope, rotator, croc, null, () ->GamePiece.CONE),
-        new InstantCommand(()->croc.setIntakeSpeed(-1)),
+        new HighPresetSequence(telescope, rotator, croc, null, () -> GamePiece.CONE),
+        new HighPresetSequence(telescope, rotator, croc, null, () -> GamePiece.CONE),
+        new InstantCommand(() -> croc.setIntakeSpeed(-1)),
         new WaitCommand(0.25),
-        new InstantCommand(()->croc.setIntakeSpeed(0)),
+        new InstantCommand(() -> croc.setIntakeSpeed(0)),
         new ParallelCommandGroup(
-          new StowPresetSequence(telescope, rotator, croc).withTimeout(3),
-          new SwerveTrajectoryFollowCommand(driveBase, "preloadParkCenter", defaultConfig, true)
-        ),
+            new StowPresetSequence(telescope, rotator, croc, () -> 0, () -> GamePiece.CONE).withTimeout(3),
+            new SwerveTrajectoryFollowCommand(driveBase, "preloadParkCenter", defaultConfig, true)),
         new LevelRobot(driveBase)
-        /*
-            * start
-         * rotate telescope to scoring position
-         * extend telescope to top position
-         * move wrist to 90 degrees
-         * drop cone using chomper
-         * move wrist back up to original position
-         * retract arm
-         * rotate arm to standby/pickup position
-         * move forward to the cone
-         * extend arm out
-         * move wrist down to grabbing position
-         * move forward some more while wrist is sucking up cone to pick it up
-         * retract arm in
-         * move back to starting position
-         * more over to the left/right in line up with poles
-         * flip arm over
-         * extend arm to top position
-         * move wrist to 90 degrees
-         * drop cone using chomper
-         * move wrist back up to original position
-         * retract arm back in
-         * rotate arm to standby/pickup position
-         * move forward onto charging station
-         * level robot command 
-             * end
-         */
-        
+    /*
+     * start
+     * rotate telescope to scoring position
+     * extend telescope to top position
+     * move wrist to 90 degrees
+     * drop cone using chomper
+     * move wrist back up to original position
+     * retract arm
+     * rotate arm to standby/pickup position
+     * move forward to the cone
+     * extend arm out
+     * move wrist down to grabbing position
+     * move forward some more while wrist is sucking up cone to pick it up
+     * retract arm in
+     * move back to starting position
+     * more over to the left/right in line up with poles
+     * flip arm over
+     * extend arm to top position
+     * move wrist to 90 degrees
+     * drop cone using chomper
+     * move wrist back up to original position
+     * retract arm back in
+     * rotate arm to standby/pickup position
+     * move forward onto charging station
+     * level robot command
+     * end
+     */
+
     );
     // grabs any requirements needed for the drivebase from other running commands.
     addRequirements(driveBase);

--- a/src/main/java/frc/robot/commands/Autos/PreloadPlusOneLeft.java
+++ b/src/main/java/frc/robot/commands/Autos/PreloadPlusOneLeft.java
@@ -43,47 +43,46 @@ public class PreloadPlusOneLeft extends SequentialCommandGroup {
     this.defaultConfig = new TrajectoryConfig(SharedConstants.AutoConstants.k_MAX_SPEED_MPS,
         SharedConstants.AutoConstants.k_MAX_ACCEL_MPS_SQUARED);
     addCommands(
-        new HighPresetSequence(telescope, rotator, croc, null, () ->GamePiece.CONE),
-        new InstantCommand(()->croc.setIntakeSpeed(-1)),
+        new HighPresetSequence(telescope, rotator, croc, null, () -> GamePiece.CONE),
+        new InstantCommand(() -> croc.setIntakeSpeed(-1)),
         new WaitCommand(0.25),
-        new InstantCommand(()->croc.setIntakeSpeed(0)),
+        new InstantCommand(() -> croc.setIntakeSpeed(0)),
         new ParallelCommandGroup(
-          new PickupPresetSequence(telescope, rotator, croc, null).withTimeout(3),
-          new SwerveTrajectoryFollowCommand(driveBase, "preloadPlusOneLeft1", defaultConfig, true)
-        ),
-        new StowPresetSequence(telescope, rotator, croc),
+            new PickupPresetSequence(telescope, rotator, croc, null).withTimeout(3),
+            new SwerveTrajectoryFollowCommand(driveBase, "preloadPlusOneLeft1", defaultConfig, true)),
+        new StowPresetSequence(telescope, rotator, croc, () -> 0, () -> GamePiece.CONE),
         new SwerveTrajectoryFollowCommand(driveBase, "preloadPlusOneLeft2", defaultConfig),
-        new HighPresetSequence(telescope, rotator, croc, null, () ->GamePiece.CONE),
-        new InstantCommand(()->croc.setIntakeSpeed(-1)),
+        new HighPresetSequence(telescope, rotator, croc, null, () -> GamePiece.CONE),
+        new InstantCommand(() -> croc.setIntakeSpeed(-1)),
         new WaitCommand(0.25),
-        new StowPresetSequence(telescope, rotator, croc)
+        new StowPresetSequence(telescope, rotator, croc, () -> 0, () -> GamePiece.CONE)
 
-        /*
-            * start
-         * rotate telescope to scoring position
-         * extend telescope to top position
-         * move wrist to 90 degrees
-         * drop cone using chomper
-         * move wrist back up to original position
-         * retract arm
-         * rotate arm to standby/pickup position
-         * move forward to the cone
-         * extend arm out
-         * move wrist down to grabbing position
-         * move forward some more while wrist is sucking up cone to pick it up
-         * retract arm in
-         * move back to starting position
-         * more over to the left/right in line up with poles
-         * flip arm over
-         * extend arm to top position
-         * move wrist to 90 degrees
-         * drop cone using chomper
-         * move wrist back up to original position
-         * retract arm back in
-         * rotate arm to standby/pickup position
-             * end
-         */
-        
+    /*
+     * start
+     * rotate telescope to scoring position
+     * extend telescope to top position
+     * move wrist to 90 degrees
+     * drop cone using chomper
+     * move wrist back up to original position
+     * retract arm
+     * rotate arm to standby/pickup position
+     * move forward to the cone
+     * extend arm out
+     * move wrist down to grabbing position
+     * move forward some more while wrist is sucking up cone to pick it up
+     * retract arm in
+     * move back to starting position
+     * more over to the left/right in line up with poles
+     * flip arm over
+     * extend arm to top position
+     * move wrist to 90 degrees
+     * drop cone using chomper
+     * move wrist back up to original position
+     * retract arm back in
+     * rotate arm to standby/pickup position
+     * end
+     */
+
     );
     // grabs any requirements needed for the drivebase from other running commands.
     addRequirements(driveBase);

--- a/src/main/java/frc/robot/commands/Autos/PreloadPlusOneRight.java
+++ b/src/main/java/frc/robot/commands/Autos/PreloadPlusOneRight.java
@@ -43,47 +43,46 @@ public class PreloadPlusOneRight extends SequentialCommandGroup {
     this.defaultConfig = new TrajectoryConfig(SharedConstants.AutoConstants.k_MAX_SPEED_MPS,
         SharedConstants.AutoConstants.k_MAX_ACCEL_MPS_SQUARED);
     addCommands(
-        new HighPresetSequence(telescope, rotator, croc, null, () ->GamePiece.CONE),
-        new InstantCommand(()->croc.setIntakeSpeed(-1)),
+        new HighPresetSequence(telescope, rotator, croc, null, () -> GamePiece.CONE),
+        new InstantCommand(() -> croc.setIntakeSpeed(-1)),
         new WaitCommand(0.25),
-        new InstantCommand(()->croc.setIntakeSpeed(0)),
+        new InstantCommand(() -> croc.setIntakeSpeed(0)),
         new ParallelCommandGroup(
-          new PickupPresetSequence(telescope, rotator, croc, null).withTimeout(3),
-          new SwerveTrajectoryFollowCommand(driveBase, "preloadPlusOneRight1", defaultConfig, true)
-        ),
-        new StowPresetSequence(telescope, rotator, croc),
+            new PickupPresetSequence(telescope, rotator, croc, null).withTimeout(3),
+            new SwerveTrajectoryFollowCommand(driveBase, "preloadPlusOneRight1", defaultConfig, true)),
+        new StowPresetSequence(telescope, rotator, croc, () -> 0, () -> GamePiece.CONE),
         new SwerveTrajectoryFollowCommand(driveBase, "preloadPlusOneRight2", defaultConfig),
-        new HighPresetSequence(telescope, rotator, croc, null, () ->GamePiece.CONE),
-        new InstantCommand(()->croc.setIntakeSpeed(-1)),
+        new HighPresetSequence(telescope, rotator, croc, null, () -> GamePiece.CONE),
+        new InstantCommand(() -> croc.setIntakeSpeed(-1)),
         new WaitCommand(0.25),
-        new StowPresetSequence(telescope, rotator, croc)
+        new StowPresetSequence(telescope, rotator, croc, () -> 0, () -> GamePiece.CONE)
 
-        /*
-            * start
-         * rotate telescope to scoring position
-         * extend telescope to top position
-         * move wrist to 90 degrees
-         * drop cone using chomper
-         * move wrist back up to original position
-         * retract arm
-         * rotate arm to standby/pickup position
-         * move forward to the cone
-         * extend arm out
-         * move wrist down to grabbing position
-         * move forward some more while wrist is sucking up cone to pick it up
-         * retract arm in
-         * move back to starting position
-         * more over to the left/right in line up with poles
-         * flip arm over
-         * extend arm to top position
-         * move wrist to 90 degrees
-         * drop cone using chomper
-         * move wrist back up to original position
-         * retract arm back in
-         * rotate arm to standby/pickup position
-             * end
-         */
-        
+    /*
+     * start
+     * rotate telescope to scoring position
+     * extend telescope to top position
+     * move wrist to 90 degrees
+     * drop cone using chomper
+     * move wrist back up to original position
+     * retract arm
+     * rotate arm to standby/pickup position
+     * move forward to the cone
+     * extend arm out
+     * move wrist down to grabbing position
+     * move forward some more while wrist is sucking up cone to pick it up
+     * retract arm in
+     * move back to starting position
+     * more over to the left/right in line up with poles
+     * flip arm over
+     * extend arm to top position
+     * move wrist to 90 degrees
+     * drop cone using chomper
+     * move wrist back up to original position
+     * retract arm back in
+     * rotate arm to standby/pickup position
+     * end
+     */
+
     );
     // grabs any requirements needed for the drivebase from other running commands.
     addRequirements(driveBase);

--- a/src/main/java/frc/robot/commands/DefaultCommands/CrocodileDefaultCommand.java
+++ b/src/main/java/frc/robot/commands/DefaultCommands/CrocodileDefaultCommand.java
@@ -38,6 +38,7 @@ public class CrocodileDefaultCommand extends CommandBase {
     // Called every time the scheduler runs while the command is scheduled.
     @Override
     public void execute() {
+        //WRIST MANUAL CONTROL
         if (Math.abs(wristTrigger.getAsDouble()) > 0.05) {
             subsystem.setWristSpeed(MathUtil.clamp(wristTrigger.getAsDouble(), -0.5, 0.5));
             subsystem.setRunPID(false);
@@ -45,14 +46,22 @@ public class CrocodileDefaultCommand extends CommandBase {
         }
         else {
             subsystem.setRunPID(true);
-        }        
-        //TODO: check if this is the right negation
+        }  
+        //INTAKE
+        double power = trigger.getAsDouble();
+        if (!subsystem.getBeamBreak()){
+            power += 0.25;
+        }
         if(subsystem.getGamePiece() == CrocodileSubsystem.GamePiece.CONE){
-            subsystem.setIntakeSpeed(trigger.getAsDouble());
+            subsystem.setIntakeSpeed(power);
         }
         else{
-            subsystem.setIntakeSpeed(-trigger.getAsDouble());
+            subsystem.setIntakeSpeed(-power);
         }
+        
+
+
+        //RUMBLE STUFF BLEOW
         // sets rumble if beam break is broken for 0.5 seconds and is not already
         // rumbling
         if (!subsystem.getBeamBreak() && !beamBreakTracker) {

--- a/src/main/java/frc/robot/commands/Presets/HighPresetSequence.java
+++ b/src/main/java/frc/robot/commands/Presets/HighPresetSequence.java
@@ -3,9 +3,12 @@ package frc.robot.commands.Presets;
 import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
 
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.ConditionalCommand;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
+import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.robot.commands.RotatorToPosition;
 import frc.robot.commands.TelescopeToPosition;
@@ -26,7 +29,10 @@ public class HighPresetSequence extends SequentialCommandGroup {
         addRequirements(rotator, telescope, crocodile);
         //thank you @mikemag for this
         DoubleSupplier multiplier = () -> gamePiece.get() == GamePiece.CONE ? 1 : -1;
+        Command runIntake = new RunCommand(() -> crocodile.setIntakeSpeed(
+                MathUtil.clamp((0.25 + intake.getAsDouble()), -1, 1) * multiplier.getAsDouble()));
         addCommands(
+            new SequentialCommandGroup(
                 new InstantCommand(() -> crocodile.setIntakeSpeed(0.25 * multiplier.getAsDouble())),
                 new RotatorToPosition(rotator, telescope, RotatorPosition.HIGH_SCORE).withTimeout(2),
                 new TelescopeToPosition(telescope, TelescopePosition.HIGH_SCORE).withTimeout(2),
@@ -34,6 +40,7 @@ public class HighPresetSequence extends SequentialCommandGroup {
                     crocodile.setWristToPositionCommand(WristPosition.CONE_SCORE), 
                     crocodile.setWristToPositionCommand(WristPosition.CUBE_SCORE), 
                     () -> crocodile.getGamePiece() == GamePiece.CONE)
+            ).deadlineWith(runIntake)
         );
         
     }

--- a/src/main/java/frc/robot/commands/Presets/MidPresetSequence.java
+++ b/src/main/java/frc/robot/commands/Presets/MidPresetSequence.java
@@ -1,9 +1,14 @@
 package frc.robot.commands.Presets;
 
+import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
 
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.ConditionalCommand;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
+import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.robot.commands.RotatorToPosition;
 import frc.robot.commands.TelescopeToPosition;
@@ -13,16 +18,27 @@ import frc.robot.subsystems.TelescopeSubsystem;
 import frc.robot.subsystems.CrocodileSubsystem.GamePiece;
 import frc.robot.subsystems.CrocodileSubsystem.WristPosition;
 import frc.robot.subsystems.RotatorSubsystem.RotatorPosition;
+import frc.robot.subsystems.TelescopeSubsystem.TelescopePosition;
 
 public class MidPresetSequence extends SequentialCommandGroup {
+
     public MidPresetSequence(TelescopeSubsystem telescope, RotatorSubsystem rotator, CrocodileSubsystem crocodile,
-            Supplier<GamePiece> gamePiece) {
+            DoubleSupplier intake, Supplier<GamePiece> gamePiece) {
         addRequirements(rotator, telescope, crocodile);
+        //thank you @mikemag for this
+        DoubleSupplier multiplier = () -> gamePiece.get() == GamePiece.CONE ? 1 : -1;
+        Command runIntake = new RunCommand(() -> crocodile.setIntakeSpeed(
+                MathUtil.clamp((0.25 + intake.getAsDouble()), -1, 1) * multiplier.getAsDouble()));
         addCommands(
+            new SequentialCommandGroup(
+                new InstantCommand(() -> crocodile.setIntakeSpeed(0.25 * multiplier.getAsDouble())),
                 new RotatorToPosition(rotator, telescope, RotatorPosition.HIGH_SCORE).withTimeout(2),
                 new ConditionalCommand(
                     crocodile.setWristToPositionCommand(WristPosition.CONE_SCORE), 
                     crocodile.setWristToPositionCommand(WristPosition.CUBE_SCORE), 
-                    () -> crocodile.getGamePiece() == GamePiece.CONE));
+                    () -> crocodile.getGamePiece() == GamePiece.CONE)
+            ).deadlineWith(runIntake)
+        );
+        
     }
 }

--- a/src/main/java/frc/robot/commands/Presets/StowPresetSequence.java
+++ b/src/main/java/frc/robot/commands/Presets/StowPresetSequence.java
@@ -1,8 +1,13 @@
 package frc.robot.commands.Presets;
 
 import java.util.function.BooleanSupplier;
+import java.util.function.DoubleSupplier;
+import java.util.function.Supplier;
 
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.robot.commands.AutoIntakeCommand;
 import frc.robot.commands.RotatorToPosition;
@@ -15,11 +20,21 @@ import frc.robot.subsystems.CrocodileSubsystem.WristPosition;
 import frc.robot.subsystems.TelescopeSubsystem.TelescopePosition;
 
 public class StowPresetSequence extends SequentialCommandGroup {
-    public StowPresetSequence(TelescopeSubsystem telescope, RotatorSubsystem rotator, CrocodileSubsystem crocodile) {
+    public StowPresetSequence(TelescopeSubsystem telescope, RotatorSubsystem rotator, CrocodileSubsystem crocodile, DoubleSupplier intake, Supplier<GamePiece> gamePiece) {
         addRequirements(telescope, rotator, crocodile);
+
+        //Thank you @mikemag for this
+        DoubleSupplier multiplier = () -> gamePiece.get() == GamePiece.CONE ? 1 : -1;
+        Command runIntake = new RunCommand(() -> crocodile.setIntakeSpeed(
+                MathUtil.clamp((0.25 + intake.getAsDouble()), -1, 1) * multiplier.getAsDouble()));
+
         addCommands(
+            new SequentialCommandGroup(
+                new InstantCommand(() -> crocodile.setIntakeSpeed(0.25 * multiplier.getAsDouble())),
                 new TelescopeToPosition(telescope, TelescopePosition.RETRACTED).withTimeout(2),
                 new RotatorToPosition(rotator, telescope, 90).withTimeout(2),
-                crocodile.setWristToPositionCommand(WristPosition.CONE_SCORE).withTimeout(2));
+                crocodile.setWristToPositionCommand(WristPosition.CONE_SCORE).withTimeout(2)
+            ).deadlineWith(runIntake)
+        );
     }
 }


### PR DESCRIPTION
We've noticed that when drivers aren't flooring a trigger, they lose cones. This PR addresses that by doing the following.
- We allow for drivers to have manual control of the intake during presets
- We passively run the intake in the correct direction for the selected gamepiece during presets
- We run the intake passively in the correct direction in the default command
These changes should make us hold gamepieces more reliably with less driver input. The exact amount of passive intake may need tuning.